### PR TITLE
[fix] Customerモデル/seedファイルのカラム名修正

### DIFF
--- a/db/migrate/20210515103906_rename_fisrt_name_column_to_customers.rb
+++ b/db/migrate/20210515103906_rename_fisrt_name_column_to_customers.rb
@@ -1,0 +1,6 @@
+class RenameFisrtNameColumnToCustomers < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :customers, :fisrt_name, :first_name
+    rename_column :customers, :kana_fisrt_name, :kana_first_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_15_062253) do
+ActiveRecord::Schema.define(version: 2021_05_15_103906) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -31,9 +31,9 @@ ActiveRecord::Schema.define(version: 2021_05_15_062253) do
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.string "last_name", null: false
-    t.string "fisrt_name", null: false
+    t.string "first_name", null: false
     t.string "kana_last_name", null: false
-    t.string "kana_fisrt_name", null: false
+    t.string "kana_first_name", null: false
     t.string "postal_code", null: false
     t.string "address", null: false
     t.string "phone_number", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,7 +31,7 @@ end
       description: "大粒イチゴのショートケーキ#{n + 1}",
       price: "#{400 + (n * 50)}",
       is_valid: [['販売中', true], ['売切れ', false]],
-      image: open("./app/assets/images/cake.jpg")
+      image_id: open("./app/assets/images/cake.jpg")
     )
   end
   4.times do |n|
@@ -40,7 +40,7 @@ end
       description: "口どけなめらかなプリン#{n + 1}",
       price: "#{200 + (n * 50)}",
       is_valid: [['販売中', true], ['売切れ', false]],
-      image: open("./app/assets/images/pudding.jpg")
+      image_id: open("./app/assets/images/pudding.jpg")
     )
   end
   5.times do |n|
@@ -49,7 +49,7 @@ end
       description: "香ばしい焼き菓子#{n + 1}",
       price: "#{200 + (n * 50)}",
       is_valid: [['販売中', true], ['売切れ', false]],
-      image: open("./app/assets/images/cookie.jpg")
+      image_id: open("./app/assets/images/cookie.jpg")
     )
   end
   3.times do |n|
@@ -58,6 +58,6 @@ end
       description: "小腹が空いたときにピッタリ!#{n + 1}",
       price: "#{120 + (n * 50)}",
       is_valid: [['販売中', true], ['売切れ', false]],
-      image: open("./app/assets/images/candy.jpg")
+      image_id: open("./app/assets/images/candy.jpg")
     )
   end


### PR DESCRIPTION
# 以下修正の上、dbを再構築

1. Customerモデルのカラム名スペルミス（以下）を修正
- "fisrt_name" → "first_name"
- "kana_fisrt_name" → "kana_first_name"

2. seedsファイルのカラム名（以下）を修正
- products関連サンプルデータの商品画像カラム名"image" → "image_id"